### PR TITLE
upgrade cf-java-client to 2.4.0.RELEASE

### DIFF
--- a/integration-test/src/test/java/com/orange/cloud/servicebroker/filter/core/filters/SecurityGroupsServiceBrokerFilterTest.java
+++ b/integration-test/src/test/java/com/orange/cloud/servicebroker/filter/core/filters/SecurityGroupsServiceBrokerFilterTest.java
@@ -40,7 +40,7 @@ public class SecurityGroupsServiceBrokerFilterTest extends AbstractServiceBroker
     }
 
     protected String getFilteredServiceBrokerOffering() {
-        return String.format("mysql-mocked-broker%s", getServiceBrokerOfferingSuffix());
+        return String.format("test-service%s", getServiceBrokerOfferingSuffix());
     }
 
     protected String getFilteredServiceBrokerPlan() {

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
 
     <properties>
         <lombok>1.16.8</lombok>
-        <cf-java-client.version>2.0.2.RELEASE</cf-java-client.version>
-        <reactor-core.version>3.0.3.RELEASE</reactor-core.version>
-        <reactor-addons.version>3.0.3.RELEASE</reactor-addons.version>
-        <reactor-netty.version>0.5.1.RELEASE</reactor-netty.version>
+        <cf-java-client.version>2.4.0.RELEASE</cf-java-client.version>
+        <reactor-core.version>3.0.5.RELEASE</reactor-core.version>
+        <reactor-addons.version>3.0.5.RELEASE</reactor-addons.version>
+        <reactor-netty.version>0.6.0.RELEASE</reactor-netty.version>
     </properties>
 
     <dependencyManagement>

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/CreateSecurityGroup.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/CreateSecurityGroup.java
@@ -25,6 +25,7 @@ import org.cloudfoundry.client.v2.applications.ApplicationEntity;
 import org.cloudfoundry.client.v2.applications.GetApplicationRequest;
 import org.cloudfoundry.client.v2.applications.GetApplicationResponse;
 import org.cloudfoundry.client.v2.securitygroups.CreateSecurityGroupRequest;
+import org.cloudfoundry.client.v2.securitygroups.Protocol;
 import org.cloudfoundry.client.v2.securitygroups.RuleEntity;
 import org.cloudfoundry.client.v2.securitygroups.SecurityGroupEntity;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +46,7 @@ import java.util.stream.Stream;
 @Component
 public class CreateSecurityGroup implements CreateServiceInstanceBindingPostFilter, ServiceBrokerPostFilter<CreateServiceInstanceBindingRequest, CreateServiceInstanceAppBindingResponse> {
 
-    static final String DEFAULT_PROTOCOL = "tcp";
+    static final Protocol DEFAULT_PROTOCOL = Protocol.TCP;
     private CloudFoundryClient cloudFoundryClient;
 
     @Autowired

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/CreateSecurityGroupTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/CreateSecurityGroupTest.java
@@ -18,7 +18,7 @@
 package com.orange.cloud.servicebroker.filter.securitygroups.filter;
 
 import org.cloudfoundry.client.CloudFoundryClient;
-import org.cloudfoundry.client.v2.CloudFoundryException;
+import org.cloudfoundry.client.v2.ClientV2Exception;
 import org.cloudfoundry.client.v2.applications.ApplicationEntity;
 import org.cloudfoundry.client.v2.applications.ApplicationsV2;
 import org.cloudfoundry.client.v2.applications.GetApplicationRequest;
@@ -78,7 +78,7 @@ public class CreateSecurityGroupTest {
                         .name("test-securitygroup-name")
                         .spaceId("space_id")
                         .rule(RuleEntity.builder()
-                                .protocol("tcp")
+                                .protocol(Protocol.TCP)
                                 .ports("3306")
                                 .destination("127.0.0.1")
                                 .build())
@@ -86,7 +86,7 @@ public class CreateSecurityGroupTest {
     }
 
 
-    @Test(expected = CloudFoundryException.class)
+    @Test(expected = ClientV2Exception.class)
     public void fail_to_create_create_security_group() throws Exception {
         givenBoundedAppExists(this.cloudFoundryClient, "app_guid");
         givenCreateSecurityGroupsFails(this.cloudFoundryClient, "test-securitygroup-name");
@@ -98,7 +98,7 @@ public class CreateSecurityGroupTest {
 
     }
 
-    @Test(expected = CloudFoundryException.class)
+    @Test(expected = ClientV2Exception.class)
     public void should_block_until_create_security_group_returns() throws Exception {
         givenBoundedAppExists(this.cloudFoundryClient, "app_guid");
         givenCreateSecurityGroupsFailsWithDelay(this.cloudFoundryClient, "test-securitygroup-name");
@@ -113,7 +113,7 @@ public class CreateSecurityGroupTest {
                         .name("test-securitygroup-name")
                         .spaceId("space_id")
                         .rule(RuleEntity.builder()
-                                .protocol("tcp")
+                                .protocol(Protocol.TCP)
                                 .ports("3306")
                                 .destination("127.0.0.1")
                                 .build())
@@ -126,12 +126,12 @@ public class CreateSecurityGroupTest {
                         .name(securityGroupName)
                         .spaceId("space_id")
                         .rule(RuleEntity.builder()
-                                .protocol("tcp")
+                                .protocol(Protocol.TCP)
                                 .ports("3306")
                                 .destination("127.0.0.1")
                                 .build())
                         .build()))
-                .willReturn(Mono.error(new CloudFoundryException(999, "test-exception-description", "test-exception-errorCode")));
+                .willReturn(Mono.error(new ClientV2Exception(null, 999, "test-exception-description", "test-exception-errorCode")));
     }
 
     private void givenCreateSecurityGroupsFailsWithDelay(CloudFoundryClient cloudFoundryClient, String securityGroupName) {
@@ -140,14 +140,14 @@ public class CreateSecurityGroupTest {
                         .name(securityGroupName)
                         .spaceId("space_id")
                         .rule(RuleEntity.builder()
-                                .protocol("tcp")
+                                .protocol(Protocol.TCP)
                                 .ports("3306")
                                 .destination("127.0.0.1")
                                 .build())
                         .build()))
                 .willReturn(Mono
                         .delay(Duration.ofSeconds(2))
-                        .then(Mono.error(new CloudFoundryException(999, "test-exception-description", "test-exception-errorCode"))));
+                        .then(Mono.error(new ClientV2Exception(null, 999, "test-exception-description", "test-exception-errorCode"))));
     }
 
     private void givenBoundedAppExists(CloudFoundryClient cloudFoundryClient, String appId) {
@@ -168,7 +168,7 @@ public class CreateSecurityGroupTest {
                         .name(securityGroupName)
                         .spaceId("space_id")
                         .rule(RuleEntity.builder()
-                                .protocol("tcp")
+                                .protocol(Protocol.TCP)
                                 .ports("3306")
                                 .destination("127.0.0.1")
                                 .build())
@@ -177,7 +177,7 @@ public class CreateSecurityGroupTest {
                         .entity(SecurityGroupEntity.builder()
                                 .name(securityGroupName)
                                 .rule(RuleEntity.builder()
-                                        .protocol("tcp")
+                                        .protocol(Protocol.TCP)
                                         .ports("3306")
                                         .destination("127.0.0.1")
                                         .build())


### PR DESCRIPTION
These changes update dependency of cf-java-client to 2.4.0.RELEASE to resolve [Token refresh issue](https://github.com/cloudfoundry/cf-java-client/issues/569).

[#32]