### PR TITLE
Support restriction of IP/port per filter deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ applications:
     #avoid service offering conflict.
     #add suffix to exiting service offering so that filter broker offering and target broker offering can exit at the same time
     #BROKER_FILTER_SERVICEOFFERING_SUFFIX=-sec
-
+    # An optional trusted IPs: single IP address, IP address range (e.g. 192.0.1.0-192.0.2.0), or a CIDR block to allow security groups to. If empty or unspecified, any IP adress returned from the binding response will be granted access in created security groups
+    BROKER_FILTER_TRUSTED_DESTINATION_HOSTS=192.0.1.0-192.0.2.0
+    # An optional trusted port range. If empty or unspecified, any port returned from the binding response will be granted access in created security groups
+    BROKER_FILTER_TRUSTED_DESTINATION_PORTS=
      
     # CloudFoundry CC api host
     CLOUDFOUNDRY_HOST: api.yourdomain.com
@@ -90,6 +93,17 @@ The resulting security group opened would be:
 [
   {"protocol":"tcp","destination":"141.8.225.68/31","ports":"3306"},
 ]
+```
+# IP/Port restriction
+
+ In order to be protected against a compromise filtered service broker (e.g. p-mysql) (that would return unowned, unrelated IPs in the binding response), 
+ IP/port range can be restricted.
+ Set following env properties to restrict IP/port range.
+```
+    # An optional trusted IPs: single IP address, IP address range (e.g. 192.0.1.0-192.0.2.0), or a CIDR block to allow security groups to. If empty or unspecified, any IP adress returned from the binding response will be granted access in created security groups
+    BROKER_FILTER_TRUSTED_DESTINATION_HOSTS=192.0.1.0-192.0.2.0
+    # An optional trusted port range. If empty or unspecified, any port returned from the binding response will be granted access in created security groups
+    BROKER_FILTER_TRUSTED_DESTINATION_PORTS=
 ```
 
 # Roadmap

--- a/service-broker-filter-securitygroups/pom.xml
+++ b/service-broker-filter-securitygroups/pom.xml
@@ -64,6 +64,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>4.2.8.RELEASE</version>

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/config/SpecificationConfig.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/config/SpecificationConfig.java
@@ -1,0 +1,94 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.config;
+
+import com.orange.cloud.servicebroker.filter.securitygroups.domain.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+
+public class SpecificationConfig {
+
+    @Configuration
+    protected static class DefaultSpecificationConfig {
+
+        @Bean
+        @ConditionalOnMissingBean
+        TrustedDestination trustedDestination() {
+            return ImmutableTrustedDestination.builder()
+                    .hosts(ImmutableCIDR.builder().value("0.0.0.0/0").build())
+                    .build();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        TrustedDestinationSpecification allowedDestinationSpecification(TrustedDestination trustedDestination) {
+            return new TrustedDestinationSpecification(trustedDestination);
+        }
+
+    }
+
+    @Configuration
+    @ConditionalOnProperty(name = "broker.filter.trusted.destination.hosts")
+    @EnableConfigurationProperties(TrustedDestinationConfig.class)
+    protected static class AllowedDestinationSpecificationConfig {
+
+
+        @Autowired
+        TrustedDestinationConfig destinationConfig;
+
+        @Bean
+        TrustedDestination trustedDestination(TrustedDestinationConfig destinationConfig) {
+            ImmutableTrustedDestination.Builder builder = ImmutableTrustedDestination.builder();
+            if (destinationConfig.getHosts() != null && !destinationConfig.getHosts().isEmpty()) {
+                final String[] range = destinationConfig.getHosts().split("-");
+                if (range.length == 1) { // a cidr or a single ip address
+                    if (range[0].contains("/")) { // a cidr
+                        builder.hosts(ImmutableCIDR.builder().value(range[0]).build());
+                    } else { // a single ip address
+                        builder.hosts(ImmutableIPAddress.builder().value(range[0]).build());
+                    }
+                } else { // a range of ports
+                    builder.hosts(ImmutableIPRange.builder()
+                            .from(ImmutableIPAddress.of(range[0]))
+                            .to(ImmutableIPAddress.of(range[1]))
+                            .build());
+                }
+
+            }
+            if (destinationConfig.getPorts() != null && !destinationConfig.getPorts().isEmpty()) {
+                final String[] range = destinationConfig.getPorts().split("-");
+                if (range.length == 1) { // a single port or multiple comma-separated ports
+                    builder.ports(ImmutablePorts.of(
+                            Stream.of(range[0].split(","))
+                                    .map(Integer::parseInt)
+                                    .map(ImmutablePort::of)
+                                    .collect(Collectors.toList())));
+                } else { // a range of ports
+                    builder.ports(ImmutablePortRange.builder()
+                            .from(ImmutablePort.of(Integer.parseInt(range[0])))
+                            .to(ImmutablePort.of(Integer.parseInt(range[1])))
+                            .build());
+                }
+
+            }
+            return builder.build();
+        }
+
+
+        @Bean
+        TrustedDestinationSpecification allowedDestinationSpecification(TrustedDestination trustedDestination) {
+            return new TrustedDestinationSpecification(trustedDestination);
+        }
+    }
+
+
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/config/TrustedDestinationConfig.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/config/TrustedDestinationConfig.java
@@ -1,0 +1,40 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+@ConfigurationProperties(prefix = "broker.filter.trusted.destination")
+public class TrustedDestinationConfig {
+
+    /*
+    A single IP address, an IP address range like 192.0.2.0-192.0.2.50, or a CIDR block to allow network access to.
+     */
+    private String hosts;
+
+    /*
+    A single port, multiple comma-separated ports, or a single range of ports that can receive traffic.
+    Examples: 443, 80,8080,8081, 8080-8081
+     */
+    private String ports;
+
+    public TrustedDestinationConfig() {
+    }
+
+    public String getHosts() {
+        return hosts;
+    }
+
+    public void setHosts(String hosts) {
+        this.hosts = hosts;
+    }
+
+    public String getPorts() {
+        return ports;
+    }
+
+    public void setPorts(String ports) {
+        this.ports = ports;
+    }
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/CIDR.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/CIDR.java
@@ -1,0 +1,40 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.apache.commons.net.util.SubnetUtils;
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+/*
+CIDR IP addresses
+ */
+@Value.Immutable
+public abstract class CIDR implements Range<IPAddress> {
+
+    @Value.Parameter
+    public abstract String value();
+
+    @Override
+    public boolean isInRange(IPAddress candidate) {
+        return Optional.ofNullable(candidate)
+                .map(IPAddress::value)
+                .map(ip -> {
+                    final SubnetUtils cidr = new SubnetUtils(value());
+                    return cidr.getInfo().isInRange(ip);
+                })
+                .orElse(Boolean.FALSE);
+
+    }
+
+    @Value.Check
+    protected void validate() {
+        try {
+            new SubnetUtils(value());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format("Invalid CIDR block : %s", value()));
+        }
+    }
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/IPAddress.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/IPAddress.java
@@ -1,0 +1,87 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.immutables.value.Value;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Some code has been copied from @link org.apache.commons.net.util.SubnetUtils
+ */
+@Value.Immutable
+public abstract class IPAddress implements Range<IPAddress> {
+
+    private static final Pattern addressPattern = Pattern.compile("(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})");
+
+    @Value.Parameter
+    public abstract String value();
+
+    @Override
+    public boolean isInRange(IPAddress candidate) {
+        return Optional.ofNullable(candidate)
+                .map(IPAddress::value)
+                .map(value()::equals)
+                .orElse(Boolean.FALSE);
+    }
+
+    @Value.Check
+    protected void validate() {
+        Matcher matcher = addressPattern.matcher(value());
+        if (!matcher.matches())
+            throw new IllegalArgumentException(String.format("Invalid IP address : %s", value()));
+    }
+
+    @Value.Lazy
+    public boolean greaterOrEqualsTo(IPAddress candidate) {
+        return Optional.ofNullable(candidate)
+                .map(IPAddress::value)
+                .map(ip -> {
+                    long ipLong = (long) this.toInteger(ip) & 4294967295L;
+                    long valueLong = (long) this.toInteger(value()) & 4294967295L;
+                    return valueLong >= ipLong;
+                })
+                .orElse(Boolean.FALSE);
+    }
+
+    @Value.Lazy
+    public boolean lessOrEqualsTo(IPAddress candidate) {
+        return Optional.ofNullable(candidate)
+                .map(IPAddress::value)
+                .map(ip -> {
+                    long ipLong = (long) this.toInteger(ip) & 4294967295L;
+                    long valueLong = (long) this.toInteger(value()) & 4294967295L;
+                    return valueLong <= ipLong;
+                })
+                .orElse(Boolean.FALSE);
+    }
+
+    private int toInteger(String address) {
+        Matcher matcher = addressPattern.matcher(address);
+        if (matcher.matches()) {
+            return this.matchAddress(matcher);
+        } else {
+            throw new IllegalArgumentException(String.format("Invalid IP address : %s", value()));
+        }
+    }
+
+    private int matchAddress(Matcher matcher) {
+        int addr = 0;
+
+        for (int i = 1; i <= 4; ++i) {
+            int n = this.rangeCheck(Integer.parseInt(matcher.group(i)), 0, 255);
+            addr |= (n & 255) << 8 * (4 - i);
+        }
+
+        return addr;
+    }
+
+    private int rangeCheck(int value, int begin, int end) {
+        if (value >= begin && value <= end) {
+            return value;
+        } else {
+            throw new IllegalArgumentException("Value [" + value + "] not in range [" + begin + "," + end + "]");
+        }
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/IPRange.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/IPRange.java
@@ -1,0 +1,30 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.immutables.value.Value;
+import org.springframework.util.Assert;
+
+import java.util.Optional;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+@Value.Immutable
+public abstract class IPRange implements Range<IPAddress> {
+
+    abstract IPAddress from();
+
+    abstract IPAddress to();
+
+    @Value.Check
+    protected void validate() {
+        Assert.isTrue(to().greaterOrEqualsTo(from()), String.format("Invalid range. %s should be greater or equals to %s", to(), from()));
+    }
+
+    @Override
+    public boolean isInRange(IPAddress candidate) {
+        return Optional.ofNullable(candidate)
+                .map(ip -> from().lessOrEqualsTo(candidate) && to().greaterOrEqualsTo(candidate))
+                .orElse(Boolean.FALSE);
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/Port.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/Port.java
@@ -1,0 +1,35 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.immutables.value.Value;
+import org.springframework.util.Assert;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+@Value.Immutable
+public abstract class Port {
+
+    @Value.Parameter
+    public abstract int value();
+
+    @Value.Lazy
+    public boolean empty() {
+        return value() == -1;
+    }
+
+    @Value.Lazy
+    public boolean greaterOrEqualsTo(Port port) {
+        return value() >= port.value();
+    }
+
+    @Value.Lazy
+    public boolean lessOrEqualsTo(Port port) {
+        return value() <= port.value();
+    }
+
+    @Value.Check
+    protected void check() {
+        Assert.isTrue(value() >= -1, String.format("Invalid port : %d", value()));
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/PortRange.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/PortRange.java
@@ -1,0 +1,23 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+@Value.Immutable
+public abstract class PortRange implements Range<Port> {
+
+    public abstract Port from();
+
+    public abstract Port to();
+
+    @Override
+    public boolean isInRange(Port candidate) {
+        return Optional.ofNullable(candidate)
+                .map(port -> port.greaterOrEqualsTo(from()) && port.lessOrEqualsTo(to()))
+                .orElse(Boolean.FALSE);
+    }
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/Ports.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/Ports.java
@@ -1,0 +1,36 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.immutables.value.Value;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+@Value.Immutable
+@Value.Style(deepImmutablesDetection = true, depluralize = true)
+public abstract class Ports implements Range<Port> {
+
+    @Value.Parameter
+    public abstract List<Port> values();
+
+    @Value.Check
+    protected void validate() {
+        if (values().isEmpty())
+            throw new IllegalArgumentException(String.format("Invalid ports. One port should at least be defined.", values()));
+    }
+
+    @Override
+    public boolean isInRange(Port candidate) {
+        return Optional.ofNullable(candidate)
+                .map(Port::value)
+                .map(port -> values().stream()
+                        .map(Port::value)
+                        .filter(port::equals)
+                        .findFirst()
+                        .map(p -> Boolean.TRUE)
+                        .orElse(Boolean.FALSE))
+                .orElse(Boolean.FALSE);
+    }
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/Range.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/Range.java
@@ -1,0 +1,10 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public interface Range<T> {
+
+    boolean isInRange(T candidate);
+
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/Specification.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/Specification.java
@@ -1,0 +1,8 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public interface Specification<T> {
+    boolean isSatisfiedBy(T candidate);
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/TrustedDestination.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/TrustedDestination.java
@@ -1,0 +1,35 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+@Value.Immutable
+@Value.Style(deepImmutablesDetection = true, depluralize = true)
+public abstract class TrustedDestination {
+
+    /*
+    A single IP address, an IP address range like 192.0.2.0-192.0.2.50, or a CIDR block to allow network access to.
+    */
+    public abstract Range<IPAddress> hosts();
+
+    /*
+    A single port, multiple comma-separated ports, or a single range of ports that can receive traffic.
+    Examples: 443, 80,8080,8081, 8080-8081
+   */
+    public abstract Optional<Range<Port>> ports();
+
+    public boolean isATrustedHost(IPAddress candidate) {
+        return hosts().isInRange(candidate);
+    }
+
+    public boolean isATrustedPort(Port port) {
+        return ports()
+                .map(ports -> ports.isInRange(port))
+                .orElse(Boolean.TRUE);
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/TrustedDestinationSpecification.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/TrustedDestinationSpecification.java
@@ -1,0 +1,20 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class TrustedDestinationSpecification implements Specification<Destination> {
+
+    private TrustedDestination trustedDestination;
+
+    public TrustedDestinationSpecification(TrustedDestination trustedDestination) {
+        this.trustedDestination = trustedDestination;
+    }
+
+    @Override
+    public boolean isSatisfiedBy(Destination candidate) {
+        return trustedDestination.isATrustedHost(ImmutableIPAddress.of(candidate.getHost()))
+                && trustedDestination.isATrustedPort(candidate.getPort());
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/ConnectionInfoFactory.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/ConnectionInfoFactory.java
@@ -17,6 +17,9 @@
 
 package com.orange.cloud.servicebroker.filter.securitygroups.filter;
 
+import com.orange.cloud.servicebroker.filter.securitygroups.domain.Destination;
+import com.orange.cloud.servicebroker.filter.securitygroups.domain.ImmutablePort;
+
 import java.util.Map;
 import java.util.Optional;
 
@@ -32,15 +35,15 @@ public class ConnectionInfoFactory {
     public static final String URI_KEYS = "uri";
 
 
-    public static ConnectionInfo fromCredentials(Map<String, Object> credentials) {
+    public static Destination fromCredentials(Map<String, Object> credentials) {
         final Optional<String> uri = ConnectionInfoFactory.getUriFromCredentials(credentials);
         final Optional<String> host = getHostFromCredentials(credentials);
         final Optional<Integer> port = getPortFromCredentials(credentials);
 
         if (uri.isPresent())
-            return new ConnectionInfo(uri.get());
+            return new Destination(uri.get());
         if (host.isPresent() && port.isPresent())
-            return new ConnectionInfo(host.get(), port.get());
+            return new Destination(host.get(), ImmutablePort.of(port.get()));
 
         throw new IllegalStateException(String.format("Cannot extract host and port from credentials %s", credentials));
     }

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/config/SpecificationConfigTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/config/SpecificationConfigTest.java
@@ -1,0 +1,136 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.config;
+
+import com.orange.cloud.servicebroker.filter.securitygroups.domain.*;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class SpecificationConfigTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @After
+    public void tearDown() {
+        if (this.context != null) {
+            this.context.close();
+            if (this.context.getParent() != null) {
+                ((ConfigurableApplicationContext) this.context.getParent()).close();
+            }
+        }
+    }
+
+    @Test
+    public void default_trusted_destination_config() {
+        MockEnvironment env = new MockEnvironment();
+        this.context = new AnnotationConfigApplicationContext();
+        this.context.setEnvironment(env);
+        this.context.register(SpecificationConfig.DefaultSpecificationConfig.class, SpecificationConfig.AllowedDestinationSpecificationConfig.class, TrustedDestinationConfig.class);
+        this.context.refresh();
+        final TrustedDestination trustedDestination = this.context.getBean(TrustedDestination.class);
+
+        Assertions.assertThat(trustedDestination).isEqualTo(ImmutableTrustedDestination.builder().hosts(ImmutableCIDR.of("0.0.0.0/0")).build());
+    }
+
+    @Test
+    public void trusted_destination_config_with_cidr() {
+        MockEnvironment env = new MockEnvironment();
+        this.context = new AnnotationConfigApplicationContext();
+        env.setProperty("broker.filter.trusted.destination.hosts", "192.168.0.1/29");
+        this.context.setEnvironment(env);
+        this.context.register(SpecificationConfig.DefaultSpecificationConfig.class, SpecificationConfig.AllowedDestinationSpecificationConfig.class);
+        this.context.refresh();
+        final TrustedDestination trustedDestination = this.context.getBean(TrustedDestination.class);
+
+        Assertions.assertThat(trustedDestination).isEqualTo(ImmutableTrustedDestination.builder()
+                .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                .build());
+    }
+
+    @Test
+    public void trusted_destination_config_with_single_ip() {
+        MockEnvironment env = new MockEnvironment();
+        this.context = new AnnotationConfigApplicationContext();
+        env.setProperty("broker.filter.trusted.destination.hosts", "192.168.0.1");
+        this.context.setEnvironment(env);
+        this.context.register(SpecificationConfig.DefaultSpecificationConfig.class, SpecificationConfig.AllowedDestinationSpecificationConfig.class);
+        this.context.refresh();
+        final TrustedDestination trustedDestination = this.context.getBean(TrustedDestination.class);
+
+        Assertions.assertThat(trustedDestination).isEqualTo(ImmutableTrustedDestination.builder()
+                .hosts(ImmutableIPAddress.of("192.168.0.1"))
+                .build());
+    }
+
+    @Test
+    public void trusted_destination_config_with_ip_range() {
+        MockEnvironment env = new MockEnvironment();
+        this.context = new AnnotationConfigApplicationContext();
+        env.setProperty("broker.filter.trusted.destination.hosts", "192.168.0.1-192.168.0.9");
+        this.context.setEnvironment(env);
+        this.context.register(SpecificationConfig.DefaultSpecificationConfig.class, SpecificationConfig.AllowedDestinationSpecificationConfig.class);
+        this.context.refresh();
+        final TrustedDestination trustedDestination = this.context.getBean(TrustedDestination.class);
+
+        Assertions.assertThat(trustedDestination).isEqualTo(ImmutableTrustedDestination.builder()
+                .hosts(ImmutableIPRange.builder().from(ImmutableIPAddress.of("192.168.0.1")).to(ImmutableIPAddress.of("192.168.0.9")).build())
+                .build());
+    }
+
+    @Test
+    public void trusted_destination_config_with_cidr_and_port_range() {
+        MockEnvironment env = new MockEnvironment();
+        this.context = new AnnotationConfigApplicationContext();
+        env.setProperty("broker.filter.trusted.destination.hosts", "192.168.0.1/29");
+        env.setProperty("broker.filter.trusted.destination.ports", "3306-3310");
+        this.context.setEnvironment(env);
+        this.context.register(SpecificationConfig.DefaultSpecificationConfig.class, SpecificationConfig.AllowedDestinationSpecificationConfig.class);
+        this.context.refresh();
+        final TrustedDestination trustedDestination = this.context.getBean(TrustedDestination.class);
+
+        Assertions.assertThat(trustedDestination).isEqualTo(ImmutableTrustedDestination.builder()
+                .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                .ports(ImmutablePortRange.builder().from(ImmutablePort.of(3306)).to(ImmutablePort.of(3310)).build())
+                .build());
+    }
+
+    @Test
+    public void trusted_destination_config_with_cidr_and_port_list() {
+        MockEnvironment env = new MockEnvironment();
+        this.context = new AnnotationConfigApplicationContext();
+        env.setProperty("broker.filter.trusted.destination.hosts", "192.168.0.1/29");
+        env.setProperty("broker.filter.trusted.destination.ports", "3306,3310");
+        this.context.setEnvironment(env);
+        this.context.register(SpecificationConfig.DefaultSpecificationConfig.class, SpecificationConfig.AllowedDestinationSpecificationConfig.class);
+        this.context.refresh();
+        final TrustedDestination trustedDestination = this.context.getBean(TrustedDestination.class);
+
+        Assertions.assertThat(trustedDestination).isEqualTo(ImmutableTrustedDestination.builder()
+                .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                .ports(ImmutablePorts.builder().addValue(3306).addValue(3310).build())
+                .build());
+    }
+
+    @Test
+    public void trusted_destination_config_with_cidr_and_single_port() {
+        MockEnvironment env = new MockEnvironment();
+        this.context = new AnnotationConfigApplicationContext();
+        env.setProperty("broker.filter.trusted.destination.hosts", "192.168.0.1/29");
+        env.setProperty("broker.filter.trusted.destination.ports", "3306");
+        this.context.setEnvironment(env);
+        this.context.register(SpecificationConfig.DefaultSpecificationConfig.class, SpecificationConfig.AllowedDestinationSpecificationConfig.class);
+        this.context.refresh();
+        final TrustedDestination trustedDestination = this.context.getBean(TrustedDestination.class);
+
+        Assertions.assertThat(trustedDestination).isEqualTo(ImmutableTrustedDestination.builder()
+                .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                .ports(ImmutablePorts.builder().addValue(3306).build())
+                .build());
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/CIDRTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/CIDRTest.java
@@ -1,0 +1,41 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class CIDRTest {
+
+    @Test
+    public void invalid_cidr() throws Exception {
+        Throwable thrown = catchThrowable(() -> {
+                    ImmutableCIDR.builder()
+                            .value("1234")
+                            .build();
+                }
+        );
+        assertThat(thrown).hasMessageContaining("Invalid CIDR block : 1234");
+    }
+
+    @Test
+    public void valid_cidr() throws Exception {
+        ImmutableCIDR.builder()
+                .value("192.168.0.1/24")
+                .build();
+    }
+
+    @Test
+    public void in_range() throws Exception {
+        final Range<IPAddress> range = ImmutableCIDR.builder().value("192.168.0.1/29").build();
+        Assertions.assertThat(range.isInRange(ImmutableIPAddress.of("192.168.0.1"))).isTrue();
+        Assertions.assertThat(range.isInRange(ImmutableIPAddress.of("192.168.0.6"))).isTrue();
+        Assertions.assertThat(range.isInRange(ImmutableIPAddress.of("192.168.1.0"))).isFalse();
+        Assertions.assertThat(range.isInRange(ImmutableIPAddress.of("127.0.0.3"))).isFalse();
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/DestinationTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/DestinationTest.java
@@ -15,7 +15,7 @@
  * -->
  */
 
-package com.orange.cloud.servicebroker.filter.securitygroups.filter;
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
@@ -26,58 +26,58 @@ import java.util.stream.Collectors;
 /**
  * @author Sebastien Bortolussi
  */
-public class ConnectionInfoTest {
+public class DestinationTest {
 
     @Test
     public void connection_info_from_uri() throws Exception {
-        ConnectionInfo connectionInfo = new ConnectionInfo("mysql://2106:Uq3YCioVsO3Dbcp4@127.0.0.1:3306/mydb?reconnect=true");
+        Destination destination = new Destination("mysql://2106:Uq3YCioVsO3Dbcp4@127.0.0.1:3306/mydb?reconnect=true");
 
-        Assert.assertEquals("127.0.0.1", connectionInfo.getHost());
-        Assert.assertEquals(3306, connectionInfo.getPort());
+        Assert.assertEquals("127.0.0.1", destination.getHost());
+        Assert.assertEquals(ImmutablePort.of(3306), destination.getPort());
     }
 
     @Test
     public void connection_info_from_host_and_port() throws Exception {
-        ConnectionInfo connectionInfo = new ConnectionInfo("127.0.0.1", 3306);
+        Destination destination = new Destination("127.0.0.1", ImmutablePort.of(3306));
 
-        Assert.assertEquals("127.0.0.1", connectionInfo.getHost());
-        Assert.assertEquals(3306, connectionInfo.getPort());
+        Assert.assertEquals("127.0.0.1", destination.getHost());
+        Assert.assertEquals(ImmutablePort.of(3306), destination.getPort());
     }
 
     @Test
     public void get_ips_from_uri() throws Exception {
-        ConnectionInfo connectionInfo = new ConnectionInfo("mysql://2106:Uq3YCioVsO3Dbcp4@localhost:3306/mydb?reconnect=true");
+        Destination destination = new Destination("mysql://2106:Uq3YCioVsO3Dbcp4@localhost:3306/mydb?reconnect=true");
 
-        Assertions.assertThat(connectionInfo.getIPs().collect(Collectors.toList())).containsOnly("127.0.0.1", "0:0:0:0:0:0:0:1");
+        Assertions.assertThat(destination.getIPs().collect(Collectors.toList())).containsOnly("127.0.0.1", "0:0:0:0:0:0:0:1");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void fail_to_create_connection_info_from_uri_with_no_port() throws Exception {
-        new ConnectionInfo("mysql://2106:Uq3YCioVsO3Dbcp4@127.0.0.1/mydb?reconnect=true");
+        new Destination("mysql://2106:Uq3YCioVsO3Dbcp4@127.0.0.1/mydb?reconnect=true");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void fail_to_create_connection_info_from_host_no_port() throws Exception {
-        new ConnectionInfo("127.0.0.1", -1);
+    public void fail_to_create_connection_info_invalid_port() throws Exception {
+        new Destination("127.0.0.1", ImmutablePort.of(-2));
     }
 
     @Test
     public void connection_info_with_default_http_port_if_http_uri_with_no_port() throws Exception {
-        ConnectionInfo connectionInfo = new ConnectionInfo("http://mysite.org/path");
+        Destination destination = new Destination("http://mysite.org/path");
 
-        Assert.assertEquals(80, connectionInfo.getPort());
+        Assert.assertEquals(ImmutablePort.of(80), destination.getPort());
     }
 
     @Test
     public void connection_info_with_default_https_port_if_https_uri_with_no_port() throws Exception {
-        ConnectionInfo connectionInfo = new ConnectionInfo("https://mysite.org/path");
+        Destination destination = new Destination("https://mysite.org/path");
 
-        Assert.assertEquals(443, connectionInfo.getPort());
+        Assert.assertEquals(ImmutablePort.of(443), destination.getPort());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void fail_to_create_connection_info_from_uri_with_no_port_and_no_default_port_defined() throws Exception {
-        new ConnectionInfo("scheme://mysite.org/path");
+        new Destination("scheme://mysite.org/path");
     }
 
 }

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/IPAddressTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/IPAddressTest.java
@@ -1,0 +1,53 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class IPAddressTest {
+
+    @Test
+    public void invalid_ip_address() throws Exception {
+        Throwable thrown = catchThrowable(() -> {
+                    ImmutableIPAddress.of("1234");
+                }
+        );
+        assertThat(thrown).hasMessageContaining("Invalid IP address : 1234");
+    }
+
+    @Test
+    public void valid_ip_address() throws Exception {
+        ImmutableIPAddress.of("127.0.0.1");
+    }
+
+    @Test
+    public void greater_than() throws Exception {
+        assertThat(ImmutableIPAddress.of("127.0.0.1").greaterOrEqualsTo(ImmutableIPAddress.of("127.0.0.1"))).isTrue();
+        assertThat(ImmutableIPAddress.of("127.0.0.1").greaterOrEqualsTo(ImmutableIPAddress.of("127.0.0.0"))).isTrue();
+
+        assertThat(ImmutableIPAddress.of("127.0.0.1").greaterOrEqualsTo(ImmutableIPAddress.of("127.0.0.2"))).isFalse();
+    }
+
+    @Test
+    public void less_than() throws Exception {
+        assertThat(ImmutableIPAddress.of("127.0.0.1").lessOrEqualsTo(ImmutableIPAddress.of("127.0.0.1"))).isTrue();
+        assertThat(ImmutableIPAddress.of("127.0.0.1").lessOrEqualsTo(ImmutableIPAddress.of("127.0.0.2"))).isTrue();
+
+        assertThat(ImmutableIPAddress.of("127.0.0.1").lessOrEqualsTo(ImmutableIPAddress.of("127.0.0.0"))).isFalse();
+    }
+
+
+    @Test
+    public void in_range() throws Exception {
+        final Range<IPAddress> range = ImmutableIPAddress.of("127.0.0.1");
+        Assertions.assertThat(range.isInRange(ImmutableIPAddress.of("127.0.0.1"))).isTrue();
+        Assertions.assertThat(range.isInRange(ImmutableIPAddress.of("127.0.0.2"))).isFalse();
+        Assertions.assertThat(range.isInRange(ImmutableIPAddress.of("127.0.0.3"))).isFalse();
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/IPRangeTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/IPRangeTest.java
@@ -1,0 +1,39 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class IPRangeTest {
+
+    @Test
+    public void invalid_range() throws Exception {
+        Throwable thrown = catchThrowable(() -> {
+                    ImmutableIPRange.builder()
+                            .from(ImmutableIPAddress.of("127.0.0.10"))
+                            .to(ImmutableIPAddress.of("127.0.0.0"))
+                            .build();
+                }
+        );
+        assertThat(thrown).hasMessageContaining("Invalid range. IPAddress{value=127.0.0.0} should be greater or equals to IPAddress{value=127.0.0.10}");
+    }
+
+    @Test
+    public void isInRange() throws Exception {
+        final IPRange IPRange = ImmutableIPRange.builder()
+                .from(ImmutableIPAddress.of("127.0.0.1"))
+                .to(ImmutableIPAddress.of("127.0.0.3"))
+                .build();
+        Assertions.assertThat(IPRange.isInRange(ImmutableIPAddress.of("127.0.0.1"))).isTrue();
+        Assertions.assertThat(IPRange.isInRange(ImmutableIPAddress.of("127.0.0.2"))).isTrue();
+        Assertions.assertThat(IPRange.isInRange(ImmutableIPAddress.of("127.0.0.3"))).isTrue();
+
+        Assertions.assertThat(IPRange.isInRange(ImmutableIPAddress.of("127.0.0.0"))).isFalse();
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/PortRangeTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/PortRangeTest.java
@@ -1,0 +1,24 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class PortRangeTest {
+
+    @Test
+    public void isInRange() throws Exception {
+        final PortRange portRange = ImmutablePortRange.builder().from(ImmutablePort.of(8000)).to(ImmutablePort.of(8002)).build();
+        Assertions.assertThat(portRange.isInRange(ImmutablePort.of(8000))).isTrue();
+        Assertions.assertThat(portRange.isInRange(ImmutablePort.of(8001))).isTrue();
+        Assertions.assertThat(portRange.isInRange(ImmutablePort.of(8002))).isTrue();
+
+        Assertions.assertThat(portRange.isInRange(ImmutablePort.of(8003))).isFalse();
+        Assertions.assertThat(portRange.isInRange(ImmutablePort.of(9000))).isFalse();
+
+    }
+
+
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/PortTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/PortTest.java
@@ -1,0 +1,44 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class PortTest {
+
+    @Test
+    public void invalid_port() throws Exception {
+        Throwable thrown = catchThrowable(() -> {
+                    ImmutablePort.of(-2);
+                }
+        );
+        assertThat(thrown).hasMessageContaining("Invalid port : -2");
+    }
+
+    @Test
+    public void valid_port() throws Exception {
+        ImmutablePort.of(8000);
+    }
+
+    @Test
+    public void greater_than() throws Exception {
+        assertThat(ImmutablePort.of(8000).greaterOrEqualsTo(ImmutablePort.of(8000))).isTrue();
+        assertThat(ImmutablePort.of(8000).greaterOrEqualsTo(ImmutablePort.of(7999))).isTrue();
+
+        assertThat(ImmutablePort.of(8000).greaterOrEqualsTo(ImmutablePort.of(8001))).isFalse();
+    }
+
+    @Test
+    public void less_than() throws Exception {
+        assertThat(ImmutablePort.of(8001).lessOrEqualsTo(ImmutablePort.of(8001))).isTrue();
+        assertThat(ImmutablePort.of(8001).lessOrEqualsTo(ImmutablePort.of(8002))).isTrue();
+
+        assertThat(ImmutablePort.of(8001).lessOrEqualsTo(ImmutablePort.of(8000))).isFalse();
+    }
+
+
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/PortsTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/PortsTest.java
@@ -1,0 +1,38 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class PortsTest {
+
+    @Test
+    public void invalid_ports() throws Exception {
+        Throwable thrown = catchThrowable(() -> {
+                    ImmutablePorts.builder().build();
+                }
+        );
+        assertThat(thrown).hasMessageContaining("Invalid ports. One port should at least be defined.");
+    }
+
+    @Test
+    public void valid_ports() throws Exception {
+        ImmutablePorts.builder().addValue(ImmutablePort.of(8000)).build();
+    }
+
+    @Test
+    public void in_range() throws Exception {
+        final Range<Port> range = ImmutablePorts.builder()
+                .addValue(ImmutablePort.of(8000))
+                .addValue(ImmutablePort.of(8001))
+                .build();
+        Assertions.assertThat(range.isInRange(ImmutablePort.of(8000))).isTrue();
+        Assertions.assertThat(range.isInRange(ImmutablePort.of(8001))).isTrue();
+        Assertions.assertThat(range.isInRange(ImmutablePort.of(9000))).isFalse();
+    }
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/TrustedDestinationSpecificationTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/TrustedDestinationSpecificationTest.java
@@ -1,0 +1,107 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class TrustedDestinationSpecificationTest {
+
+    @Test
+    public void in_cidr_destination_host_should_satisfy_specification() throws Exception {
+        final TrustedDestinationSpecification trustedDestinationSpecification = new TrustedDestinationSpecification(
+                ImmutableTrustedDestination.builder()
+                        .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                        .build());
+        final boolean satisfiedBy = trustedDestinationSpecification.isSatisfiedBy(new Destination("192.168.0.1", ImmutablePort.of(8000)));
+        Assertions.assertThat(satisfiedBy).isTrue();
+    }
+
+    @Test
+    public void in_range_destination_host_should_satisfy_specification() throws Exception {
+        final TrustedDestinationSpecification trustedDestinationSpecification = new TrustedDestinationSpecification(
+                ImmutableTrustedDestination.builder()
+                        .hosts(ImmutableIPRange.builder().from(ImmutableIPAddress.of("192.168.0.1")).to(ImmutableIPAddress.of("192.168.0.2")).build())
+                        .build());
+        final boolean satisfiedBy = trustedDestinationSpecification.isSatisfiedBy(new Destination("192.168.0.1", ImmutablePort.of(8000)));
+        Assertions.assertThat(satisfiedBy).isTrue();
+    }
+
+    @Test
+    public void out_of_cidr_destination_host_should_not_satisfy_specification() throws Exception {
+        final TrustedDestinationSpecification trustedDestinationSpecification = new TrustedDestinationSpecification(
+                ImmutableTrustedDestination.builder()
+                        .hosts(ImmutableCIDR.of("192.168.0.1/29")).build());
+        final boolean satisfiedBy = trustedDestinationSpecification.isSatisfiedBy(new Destination("192.168.0.10", ImmutablePort.of(8000)));
+        Assertions.assertThat(satisfiedBy).isFalse();
+    }
+
+    @Test
+    public void out_of_range_destination_host_should_not_satisfy_specification() throws Exception {
+        final TrustedDestinationSpecification trustedDestinationSpecification = new TrustedDestinationSpecification(
+                ImmutableTrustedDestination.builder()
+                        .hosts(ImmutableIPRange.builder().from(ImmutableIPAddress.of("192.168.0.1")).to(ImmutableIPAddress.of("192.168.0.2")).build())
+                        .build());
+        final boolean satisfiedBy = trustedDestinationSpecification.isSatisfiedBy(new Destination("192.168.0.10", ImmutablePort.of(8000)));
+        Assertions.assertThat(satisfiedBy).isFalse();
+    }
+
+    @Test
+    public void in_range_destination_port_should_satisfy_specification() throws Exception {
+        final TrustedDestinationSpecification trustedDestinationSpecification = new TrustedDestinationSpecification(
+                ImmutableTrustedDestination.builder()
+                        .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                        .ports(ImmutablePortRange.builder()
+                                .from(ImmutablePort.of(8000))
+                                .to(ImmutablePort.of(8009))
+                                .build())
+                        .build());
+        final boolean satisfiedBy = trustedDestinationSpecification.isSatisfiedBy(new Destination("192.168.0.1", ImmutablePort.of(8000)));
+        Assertions.assertThat(satisfiedBy).isTrue();
+    }
+
+
+    @Test
+    public void out_of_range_destination_port_should_not_satisfy_specification() throws Exception {
+        final TrustedDestinationSpecification trustedDestinationSpecification = new TrustedDestinationSpecification(
+                ImmutableTrustedDestination.builder()
+                        .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                        .ports(ImmutablePortRange.builder()
+                                .from(ImmutablePort.of(8000))
+                                .to(ImmutablePort.of(8009))
+                                .build())
+                        .build());
+        final boolean satisfiedBy = trustedDestinationSpecification.isSatisfiedBy(new Destination("192.168.0.1", ImmutablePort.of(8010)));
+        Assertions.assertThat(satisfiedBy).isFalse();
+    }
+
+    @Test
+    public void in_list_destination_port_should_satisfy_specification() throws Exception {
+        final TrustedDestinationSpecification trustedDestinationSpecification = new TrustedDestinationSpecification(
+                ImmutableTrustedDestination.builder()
+                        .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                        .ports(ImmutablePorts.builder()
+                                .addValue(ImmutablePort.of(8000))
+                                .addValue(ImmutablePort.of(8001))
+                                .build())
+                        .build());
+        final boolean satisfiedBy = trustedDestinationSpecification.isSatisfiedBy(new Destination("192.168.0.1", ImmutablePort.of(8000)));
+        Assertions.assertThat(satisfiedBy).isTrue();
+    }
+
+    @Test
+    public void out_of_list_destination_port_should_satisfy_specification() throws Exception {
+        final TrustedDestinationSpecification trustedDestinationSpecification = new TrustedDestinationSpecification(
+                ImmutableTrustedDestination.builder()
+                        .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                        .ports(ImmutablePorts.builder()
+                                .addValue(ImmutablePort.of(8000))
+                                .addValue(ImmutablePort.of(8001))
+                                .build())
+                        .build());
+        final boolean satisfiedBy = trustedDestinationSpecification.isSatisfiedBy(new Destination("192.168.0.1", ImmutablePort.of(8010)));
+        Assertions.assertThat(satisfiedBy).isFalse();
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/TrustedDestinationTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/domain/TrustedDestinationTest.java
@@ -1,0 +1,67 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class TrustedDestinationTest {
+
+    @Test
+    public void hosts_is_mandatory() throws Exception {
+        Throwable thrown = catchThrowable(() -> {
+                    ImmutableTrustedDestination.builder().build();
+                }
+        );
+        assertThat(thrown).hasMessageContaining("Cannot build TrustedDestination, some of required attributes are not set [hosts]");
+    }
+
+    @Test
+    public void with_cidr_for_host() throws Exception {
+        final ImmutableTrustedDestination destination = ImmutableTrustedDestination.builder().hosts(ImmutableCIDR.of("192.168.0.1/29")).build();
+        Assertions.assertThat(destination.hosts()).isEqualTo(ImmutableCIDR.of("192.168.0.1/29"));
+    }
+
+    @Test
+    public void with_single_ip_for_host() throws Exception {
+        final ImmutableTrustedDestination destination = ImmutableTrustedDestination.builder().hosts(ImmutableIPAddress.of("192.168.0.1")).build();
+        Assertions.assertThat(destination.hosts()).isEqualTo(ImmutableIPAddress.of("192.168.0.1"));
+    }
+
+    @Test
+    public void with_ip_range_for_host() throws Exception {
+        final ImmutableTrustedDestination destination = ImmutableTrustedDestination.builder()
+                .hosts(ImmutableIPRange.builder()
+                        .from(ImmutableIPAddress.of("192.168.0.1"))
+                        .to(ImmutableIPAddress.of("192.168.0.7"))
+                        .build())
+                .build();
+        Assertions.assertThat(destination.hosts()).isEqualTo(ImmutableIPRange.builder()
+                .from(ImmutableIPAddress.of("192.168.0.1"))
+                .to(ImmutableIPAddress.of("192.168.0.7"))
+                .build());
+    }
+
+    @Test
+    public void with_ports() throws Exception {
+        ImmutableTrustedDestination.builder()
+                .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                .ports(ImmutablePorts.builder()
+                        .addValue(ImmutablePort.of(3306))
+                        .build())
+                .build();
+    }
+
+    @Test
+    public void with_port_range() throws Exception {
+        ImmutableTrustedDestination.builder()
+                .hosts(ImmutableCIDR.of("192.168.0.1/29"))
+                .ports(ImmutablePortRange.builder().from(ImmutablePort.of(3306)).to(ImmutablePort.of(3310)).build())
+                .build();
+    }
+
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/DestinationFactoryTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/DestinationFactoryTest.java
@@ -17,6 +17,9 @@
 
 package com.orange.cloud.servicebroker.filter.securitygroups.filter;
 
+import com.orange.cloud.servicebroker.filter.securitygroups.domain.Destination;
+import com.orange.cloud.servicebroker.filter.securitygroups.domain.ImmutablePort;
+import com.orange.cloud.servicebroker.filter.securitygroups.domain.Port;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,7 +29,7 @@ import java.util.Map;
 /**
  * @author Sebastien Bortolussi
  */
-public class ConnectionInfoFactoryTest {
+public class DestinationFactoryTest {
 
     @Test
     public void uri_from_credentials() throws Exception {
@@ -34,18 +37,18 @@ public class ConnectionInfoFactoryTest {
         Map<String, Object> credentials = new HashMap<>();
         credentials.put("uri", uri);
 
-        Assert.assertEquals(new ConnectionInfo(uri), ConnectionInfoFactory.fromCredentials(credentials));
+        Assert.assertEquals(new Destination(uri), ConnectionInfoFactory.fromCredentials(credentials));
     }
 
     @Test
     public void hostname_and_port_from_credentials() throws Exception {
         String hostname = "127.0.0.1";
-        int port = 6379;
+        Port port = ImmutablePort.of(6379);
         Map<String, Object> credentials = new HashMap<>();
         credentials.put("hostname", hostname);
-        credentials.put("port", port);
+        credentials.put("port", port.value());
 
-        Assert.assertEquals(new ConnectionInfo(hostname, port), ConnectionInfoFactory.fromCredentials(credentials));
+        Assert.assertEquals(new Destination(hostname, port), ConnectionInfoFactory.fromCredentials(credentials));
     }
 
     @Test(expected = Exception.class)


### PR DESCRIPTION
These changes add support for restriction of  the IP/port range that sec-group-broker-filter instance will open onto.

[#17]