### PR TITLE
Fail fast on bad cloudfoundry credentials

### DIFF
--- a/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/config/CheckCloudFoundryConnection.java
+++ b/service-broker-filter-securitygroups/src/main/java/com/orange/cloud/servicebroker/filter/securitygroups/config/CheckCloudFoundryConnection.java
@@ -1,0 +1,27 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.config;
+
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.info.GetInfoRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * This code forces a connection to CloudFoundry with provided credentials on app startup.
+ * When bad credentials exception, app fails to start.
+ *
+ */
+@Component
+public class CheckCloudFoundryConnection implements CommandLineRunner {
+
+    @Autowired
+    CloudFoundryClient cloudFoundryClient;
+
+    @Override
+    public void run(String... strings) throws Exception {
+        //basic get on info endpoint so as to perform a CloudFoundry CC API connection and thus assert credentials are valid
+        cloudFoundryClient.info().get(GetInfoRequest.builder().build()).block(Duration.ofMinutes(3));
+    }
+}

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/config/CheckCloudFoundryConnectionTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/config/CheckCloudFoundryConnectionTest.java
@@ -1,0 +1,60 @@
+package com.orange.cloud.servicebroker.filter.securitygroups.config;
+
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.info.GetInfoRequest;
+import org.cloudfoundry.client.v2.info.Info;
+import org.cloudfoundry.uaa.UaaException;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.hamcrest.Matchers.isA;
+
+public class CheckCloudFoundryConnectionTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private ConfigurableApplicationContext context;
+
+    @After
+    public void cleanUp() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    public void fail_to_start_app_when_cloudFoundry_cc_API_bad_credentials() throws Exception {
+        //Should fail when Bad Credentials
+        this.thrown.expectCause(isA(UaaException.class));
+        this.context = new SpringApplicationBuilder(TestConfiguration.class).web(false).run();
+    }
+
+    @Configuration
+    static class TestConfiguration {
+
+        @Bean
+        public CloudFoundryClient cloudFoundryClient() {
+            final Info info = Mockito.mock(Info.class);
+            //fail to connect to CloudFoundry CC API with bad credentials exception
+            Mockito.when(info.get(GetInfoRequest.builder().build())).thenThrow(new UaaException(401, "unauthorized", "Bad credentials"));
+            final CloudFoundryClient cloudFoundryClient = Mockito.mock(CloudFoundryClient.class);
+            Mockito.when(cloudFoundryClient.info()).thenReturn(info);
+            return cloudFoundryClient;
+        }
+
+        @Bean
+        CheckCloudFoundryConnection checkCloudFoundryConnection() {
+            return new CheckCloudFoundryConnection();
+        }
+
+    }
+
+}


### PR DESCRIPTION
These changes add support to fail app startup on bad CloudFoundry CC API credentials.

[#41]