### PR TITLE
Fail service binding on filter error

### DIFF
--- a/service-broker-filter-core/src/test/java/com/orange/cloud/servicebroker/filter/core/service/ServiceInstanceBindingServiceProxyTest.java
+++ b/service-broker-filter-core/src/test/java/com/orange/cloud/servicebroker/filter/core/service/ServiceInstanceBindingServiceProxyTest.java
@@ -19,7 +19,9 @@ package com.orange.cloud.servicebroker.filter.core.service;
 
 import com.orange.cloud.servicebroker.filter.core.filters.ServiceInstanceBindingFilterRunner;
 import com.orange.cloud.servicebroker.filter.core.service.mapper.DefaultServiceInstanceBindingRequestMapper;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -38,6 +40,9 @@ import org.springframework.http.ResponseEntity;
 @RunWith(MockitoJUnitRunner.class)
 public class ServiceInstanceBindingServiceProxyTest {
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Spy
     DefaultServiceInstanceBindingRequestMapper mapper;
     @Mock
@@ -47,17 +52,48 @@ public class ServiceInstanceBindingServiceProxyTest {
     @InjectMocks
     private ServiceInstanceBindingServiceProxy serviceInstanceBindingServiceProxy;
 
-    @Test
-    public void should_proxy_create_service_instance_binding_request_to_filtered_broker() throws Exception {
-        CreateServiceInstanceBindingRequest request = new CreateServiceInstanceBindingRequest()
+    private static ResponseEntity<CreateServiceInstanceAppBindingResponse> created() {
+        return new ResponseEntity<CreateServiceInstanceAppBindingResponse>(new CreateServiceInstanceAppBindingResponse(), HttpStatus.CREATED);
+    }
+
+    private static CreateServiceInstanceBindingRequest createServiceInstanceBindingRequest() {
+        return new CreateServiceInstanceBindingRequest()
                 .withServiceInstanceId("instance_id")
                 .withBindingId("binding_id");
-        ResponseEntity<CreateServiceInstanceAppBindingResponse> response = new ResponseEntity<CreateServiceInstanceAppBindingResponse>(new CreateServiceInstanceAppBindingResponse(), HttpStatus.CREATED);
-        Mockito.when(client.createServiceInstanceBinding("instance_id", "binding_id", request)).thenReturn(response);
+    }
 
-        serviceInstanceBindingServiceProxy.createServiceInstanceBinding(request);
+    @Test
+    public void should_proxy_create_service_instance_binding_request_to_filtered_broker() throws Exception {
+        Mockito.when(client.createServiceInstanceBinding("instance_id", "binding_id", createServiceInstanceBindingRequest()))
+                .thenReturn(created());
 
-        Mockito.verify(client).createServiceInstanceBinding("instance_id", "binding_id", request);
+        serviceInstanceBindingServiceProxy.createServiceInstanceBinding(createServiceInstanceBindingRequest());
+
+        Mockito.verify(client).createServiceInstanceBinding("instance_id", "binding_id", createServiceInstanceBindingRequest());
+    }
+
+    @Test
+    public void should_fail_to_create_service_instance_instance_when_any_post_filter_fails() throws Exception {
+        Mockito.when(client.createServiceInstanceBinding("instance_id", "binding_id", createServiceInstanceBindingRequest()))
+                .thenReturn(created());
+        Mockito.doThrow(new RuntimeException("filter failed"))
+                .when(filterRunner).postBind(createServiceInstanceBindingRequest(), new CreateServiceInstanceAppBindingResponse());
+
+        this.thrown.expect(RuntimeException.class);
+        this.thrown.expectMessage("filter failed");
+
+        serviceInstanceBindingServiceProxy.createServiceInstanceBinding(createServiceInstanceBindingRequest());
+    }
+
+    @Test
+    public void should_fail_to_create_service_instance_instance_when_any_pre_filter_fails() throws Exception {
+        Mockito.doThrow(new RuntimeException("filter failed"))
+                .when(filterRunner).preBind(createServiceInstanceBindingRequest());
+
+        this.thrown.expect(RuntimeException.class);
+        this.thrown.expectMessage("filter failed");
+
+        serviceInstanceBindingServiceProxy.createServiceInstanceBinding(createServiceInstanceBindingRequest());
 
     }
 

--- a/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/CreateSecurityGroupTest.java
+++ b/service-broker-filter-securitygroups/src/test/java/com/orange/cloud/servicebroker/filter/securitygroups/filter/CreateSecurityGroupTest.java
@@ -188,7 +188,7 @@ public class CreateSecurityGroupTest {
     }
 
     @Test(expected = ClientV2Exception.class)
-    public void fail_to_create_create_security_group() throws Exception {
+    public void fail_to_create_create_security_group_should_raise_exception_so_that_CC_requests_unbinding_action_to_clean_up_target_broker_related_resources() throws Exception {
         givenBoundedAppExists(this.cloudFoundryClient, "app_guid");
         givenServicePlan(this.cloudFoundryClient, "plan-id", "service-id");
         givenService(this.cloudFoundryClient, "service-id", "service-broker-id");


### PR DESCRIPTION
These changes add tests to assert that service broker should raise a service binding error when related post filters has failed.

[#10]